### PR TITLE
fix: remove dependencies on Buffer (#24)

### DIFF
--- a/src/LoraMessage.js
+++ b/src/LoraMessage.js
@@ -48,14 +48,10 @@
   };
 
   LoraMessage.prototype.getBytes = function() {
-    var buffer = new Buffer(this.getLength());
-    var offset = 0;
-    this.dataTuples.forEach(function(tuple) {
+    return this.dataTuples.reduce(function(acc, tuple) {
       var current = tuple.fn.apply(null, tuple.data);
-      current.copy(buffer, offset);
-      offset += tuple.fn.BYTES;
-    });
-    return buffer;
+      return acc.concat(current);
+    }, []);
   };
 
   LoraMessage.prototype.getLength = function() {

--- a/src/encoder.js
+++ b/src/encoder.js
@@ -1,7 +1,7 @@
 var intToBytes = function(i, byteSize) {
-  var buf = new Buffer(byteSize);
+  var buf = [];
   for (var x = 0; x < byteSize; x++) {
-    buf[x] = i >> (x * 8);
+    buf[x] = i >> (x * 8) & 0xFF;
   }
   return buf;
 };
@@ -38,15 +38,14 @@ var latLng = function(latitude, longitude) {
     throw new Error('Longitude must be between -180° and 180°');
   }
 
-  return Buffer.concat([
+  return [].concat(
     intToBytes(~~(latitude * 1e6), latLng.BYTES / 2),
     intToBytes(~~(longitude * 1e6), latLng.BYTES / 2)
-  ]);
+  );
 };
 latLng.BYTES = 8;
 
 var temperature = function(i) {
-
   if (isNaN(i) || i < -327.68 || i > 327.67) {
     throw new Error('Temperature must be in range -327.68..327.67');
   }
@@ -62,10 +61,10 @@ var temperature = function(i) {
     }
     b = arr.map(Number).join('');
   }
-  return new Buffer([
+  return [
     parseInt(b.slice(-16, -8), 2),
     parseInt(b.slice(-8), 2)
-  ]);
+  ];
 };
 temperature.BYTES = 2;
 
@@ -106,10 +105,10 @@ var encode = function(values, mask) {
     throw new Error('Mask length is ' + mask.length + ' whereas input is ' + values.length);
   }
 
-  return Buffer.concat(values
-    .map(function(args, i) {
-      return mask[i].apply(null, Array.isArray(args) ? args : [args]);
-    }));
+  return values
+    .reduce(function(acc, args, i) {
+      return acc.concat(mask[i].apply(null, Array.isArray(args) ? args : [args]));
+    }, []);
 };
 
 if (typeof module === 'object' && typeof module.exports !== 'undefined') {

--- a/test/LoraMessage.js
+++ b/test/LoraMessage.js
@@ -23,15 +23,15 @@ test('should be possible to chain message parts', t => {
       .addBitmap.apply(loraMessage, base.bitmapArgs)
       .getBytes()
     ,
-    Buffer.concat([
+    [].concat(
       base.latLngBytes,
       base.unixtimeBytes,
       base.uint16Bytes,
       base.tempBytes,
       base.uint8Bytes,
       base.humidityBytes,
-      base.bitmapBytes,
-    ])
+      base.bitmapBytes
+    )
   );
   t.pass();
 });

--- a/test/base.js
+++ b/test/base.js
@@ -1,17 +1,17 @@
 module.exports = {
-  unixtimeBytes: new Buffer([0x1d, 0x4b, 0x7a, 0x57]),
+  unixtimeBytes: [0x1d, 0x4b, 0x7a, 0x57],
   unixtime: 1467632413,
-  uint8Bytes: new Buffer([0xFF]),
+  uint8Bytes: [0xFF],
   uint8: 255,
-  uint16Bytes: new Buffer([0x9d, 0x5b]),
+  uint16Bytes: [0x9d, 0x5b],
   uint16: 23453,
-  tempBytes: new Buffer([0x1f, 0x4c]),
+  tempBytes: [0x1f, 0x4c],
   temp: 80.12,
-  negativeTempBytes: new Buffer([0xcf, 0xc7]),
+  negativeTempBytes: [0xcf, 0xc7],
   negativeTemp: -123.45,
-  humidityBytes: new Buffer([0x0f, 0x27]),
+  humidityBytes: [0x0f, 0x27],
   humidity: 99.99,
-  latLngBytes: new Buffer([0x64, 0xa6, 0xfa, 0xfd, 0x6a, 0x24, 0x04, 0x09]),
+  latLngBytes: [0x64, 0xa6, 0xfa, 0xfd, 0x6a, 0x24, 0x04, 0x09],
   latLng: [-33.905052, 151.26641],
   bitmapArgs: [true, true, true, true, true, true, false, true],
   bitmap: {
@@ -24,7 +24,7 @@ module.exports = {
     g: false,
     h: true
   },
-  bitmapBytes: new Buffer([253]),
+  bitmapBytes: [253],
   bitmap2: {
     a: false,
     b: true,
@@ -35,5 +35,5 @@ module.exports = {
     g: false,
     h: false
   },
-  bitmap2Bytes: new Buffer([64]),
+  bitmap2Bytes: [64],
 };

--- a/test/decoder/bitmap.js
+++ b/test/decoder/bitmap.js
@@ -7,7 +7,7 @@ test('should yell at you if the buffer is omitted', t => {
   t.pass();
 });
 test('should yell at you if the buffer size is incorrect', t => {
-  t.throws(() => decoder.bitmap(new Buffer([1, 2])), /must have/);
+  t.throws(() => decoder.bitmap([1, 2]), /must have/);
   t.pass();
 });
 test('should be possible to decode a bitmap', t => {

--- a/test/decoder/decode.js
+++ b/test/decoder/decode.js
@@ -5,15 +5,15 @@ import base from '../base';
 test('should be able to compose decoder functions', t => {
   t.deepEqual(
     decoder.decode(
-      Buffer.concat([
+      [].concat(
         base.latLngBytes,
         base.unixtimeBytes,
         base.uint16Bytes,
         base.tempBytes,
         base.uint8Bytes,
         base.humidityBytes,
-        base.bitmapBytes,
-      ]), [
+        base.bitmapBytes
+      ), [
         decoder.latLng,
         decoder.unixtime,
         decoder.uint16,
@@ -37,7 +37,7 @@ test('should be able to compose decoder functions', t => {
 });
 
 test('should yell at you if mask is longer than input', t => {
-  t.throws(() => decoder.decode(new Buffer(7), [decoder.latLng]), /Mask/i);
+  t.throws(() => decoder.decode([1, 2, 3, 4, 5, 6, 7], [decoder.latLng]), /Mask/i);
   t.pass();
 });
 

--- a/test/decoder/humidity.js
+++ b/test/decoder/humidity.js
@@ -8,7 +8,7 @@ test('should yell at you if the buffer is omitted', t => {
 });
 
 test('should yell at you if the buffer size is incorrect', t => {
-  t.throws(() => decoder.humidity(new Buffer([1])), /must have/);
+  t.throws(() => decoder.humidity([1]), /must have/);
   t.pass();
 });
 

--- a/test/decoder/latLng.js
+++ b/test/decoder/latLng.js
@@ -8,7 +8,7 @@ test('should yell at you if the buffer is omitted', t => {
 });
 
 test('should yell at you if the buffer size is incorrect', t => {
-  t.throws(() => decoder.latLng(new Buffer([1, 2, 3, 4, 5, 6, 7, 8, 9])), /must have/);
+  t.throws(() => decoder.latLng([1, 2, 3, 4, 5, 6, 7, 8, 9]), /must have/);
   t.pass();
 });
 

--- a/test/decoder/temperature.js
+++ b/test/decoder/temperature.js
@@ -8,7 +8,7 @@ test('should yell at you if the buffer is omitted', t => {
 });
 
 test('should yell at you if the buffer size is incorrect', t => {
-  t.throws(() => decoder.temperature(new Buffer([1])), /must have/);
+  t.throws(() => decoder.temperature([1]), /must have/);
   t.pass();
 });
 

--- a/test/decoder/uint16.js
+++ b/test/decoder/uint16.js
@@ -8,7 +8,7 @@ test('should yell at you if the buffer is omitted', t => {
 });
 
 test('should yell at you if the buffer size is incorrect', t => {
-  t.throws(() => decoder.uint16(new Buffer([1])), /must have/);
+  t.throws(() => decoder.uint16([1]), /must have/);
   t.pass();
 });
 

--- a/test/decoder/uint8.js
+++ b/test/decoder/uint8.js
@@ -8,7 +8,7 @@ test('should yell at you if the buffer is omitted', t => {
 });
 
 test('should yell at you if the buffer size is incorrect', t => {
-  t.throws(() => decoder.uint8(new Buffer([1, 2])), /must have/);
+  t.throws(() => decoder.uint8([1, 2]), /must have/);
   t.pass();
 });
 

--- a/test/decoder/unixtime.js
+++ b/test/decoder/unixtime.js
@@ -8,7 +8,7 @@ test('should yell at you if the buffer is omitted', t => {
 });
 
 test('should yell at you if the buffer size is incorrect', t => {
-  t.throws(() => decoder.unixtime(new Buffer([1, 2])), /must have/);
+  t.throws(() => decoder.unixtime([1, 2]), /must have/);
   t.pass();
 });
 

--- a/test/encoder/bitmap.js
+++ b/test/encoder/bitmap.js
@@ -14,6 +14,6 @@ test('should be possible to encode a bitmap', t => {
 });
 
 test('should be possible to encode a short bitmap', t => {
-  t.deepEqual(encoder.bitmap(true), new Buffer([0x80]));
+  t.deepEqual(encoder.bitmap(true), [0x80]);
   t.pass();
 });

--- a/test/encoder/encode.js
+++ b/test/encoder/encode.js
@@ -34,15 +34,15 @@ test('should be able to compose encoder functions', t => {
       encoder.humidity,
       encoder.bitmap,
     ]),
-      Buffer.concat([
+      [].concat(
         base.latLngBytes,
         base.unixtimeBytes,
         base.uint16Bytes,
         base.tempBytes,
         base.uint8Bytes,
         base.humidityBytes,
-        base.bitmapBytes,
-      ])
+        base.bitmapBytes
+      )
   );
   t.pass();
 });


### PR DESCRIPTION
Fixes #24 (the EcmaScript 5 in TTN Payload Formats do not support `Buffer`), and gets rid of:

> [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.