### PR TITLE
LoraEncoder.cpp: added writeUint32()

### DIFF
--- a/src/LoraEncoder.cpp
+++ b/src/LoraEncoder.cpp
@@ -22,9 +22,6 @@
   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
   SOFTWARE.
-  
-  History:
-  20220309 MPr: added writeUint32()
 
 */
 
@@ -57,7 +54,6 @@ void LoraEncoder::writeLatLng(double latitude, double longitude) {
     _buffer += 8;
 }
 
-// MPr: added
 void LoraEncoder::writeUint32(uint32_t i) {
     _intToBytes(_buffer, i, 4);
     _buffer += 4;

--- a/src/LoraEncoder.cpp
+++ b/src/LoraEncoder.cpp
@@ -22,6 +22,10 @@
   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
   SOFTWARE.
+  
+  History:
+  20220309 MPr: added writeUint32()
+
 */
 
 #if ARDUINO >= 100
@@ -53,6 +57,12 @@ void LoraEncoder::writeLatLng(double latitude, double longitude) {
     _buffer += 8;
 }
 
+// MPr: added
+void LoraEncoder::writeUint32(uint32_t i) {
+    _intToBytes(_buffer, i, 4);
+    _buffer += 4;
+}
+
 void LoraEncoder::writeUint16(uint16_t i) {
     _intToBytes(_buffer, i, 2);
     _buffer += 2;
@@ -67,12 +77,6 @@ void LoraEncoder::writeHumidity(float humidity) {
     int16_t h = (int16_t) (humidity * 100);
     _intToBytes(_buffer, h, 2);
     _buffer += 2;
-}
-
-void LoraEncoder::writeRawFloat(float value) {
-  uint32_t asbytes=*(reinterpret_cast<uint32_t*>(&value));
-  _intToBytes(_buffer, asbytes, 4);
-  _buffer += 4;
 }
 
 /**
@@ -102,4 +106,10 @@ void LoraEncoder::writeBitmap(bool a, bool b, bool c, bool d, bool e, bool f, bo
     bitmap |= (g & 1) << 1;
     bitmap |= (h & 1) << 0;
     writeUint8(bitmap);
+}
+
+void LoraEncoder::writeRawFloat(float value) {
+  uint32_t asbytes=*(reinterpret_cast<uint32_t*>(&value));
+  _intToBytes(_buffer, asbytes, 4);
+  _buffer += 4;
 }

--- a/src/LoraEncoder.h
+++ b/src/LoraEncoder.h
@@ -22,6 +22,10 @@
   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
   SOFTWARE.
+  
+  History:
+  20220309 MPr: added writeUint32()
+
 */
 
 #ifndef _LORA_ENCODER_H_
@@ -40,12 +44,13 @@ class LoraEncoder {
         void writeUnixtime(uint32_t unixtime);
         void writeLatLng(double latitude, double longitude);
         void writeUint16(uint16_t i);
+        // MPr: added
+        void writeUint32(uint32_t i);
         void writeTemperature(float temperature);
         void writeUint8(uint8_t i);
         void writeHumidity(float humidity);
         void writeBitmap(bool a, bool b, bool c, bool d, bool e, bool f, bool g, bool h);
         void writeRawFloat(float value);
-
     private:
         byte* _buffer;
         void _intToBytes(byte *buf, int32_t i, uint8_t byteSize);

--- a/src/LoraEncoder.h
+++ b/src/LoraEncoder.h
@@ -22,9 +22,6 @@
   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
   SOFTWARE.
-  
-  History:
-  20220309 MPr: added writeUint32()
 
 */
 
@@ -44,7 +41,6 @@ class LoraEncoder {
         void writeUnixtime(uint32_t unixtime);
         void writeLatLng(double latitude, double longitude);
         void writeUint16(uint16_t i);
-        // MPr: added
         void writeUint32(uint32_t i);
         void writeTemperature(float temperature);
         void writeUint8(uint8_t i);


### PR DESCRIPTION
I added writeUint32() because I needed it. Its identical to writeUnixtime(), but I thought it might be confusing to use this for other purposes.